### PR TITLE
404 user not found on user page if user does not exist

### DIFF
--- a/api/main.go
+++ b/api/main.go
@@ -4,7 +4,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"log"
 	"net/http"
 	"os"
 
@@ -34,7 +33,7 @@ func main() {
 	}
 	if env == "dev" {
 		if err := godotenv.Load(); err != nil {
-			log.Print("No .env file found")
+			fmt.Println("No .env file found")
 		}
 	}
 
@@ -53,7 +52,7 @@ func main() {
 	r.HandleFunc("/fllws/{username}", fllwsUserHandler).Methods("GET", "POST")
 	r.HandleFunc("/fllws/{whoUsername}/{whomUsername}", doesFllwUserHandler).Methods("GET")
 	r.HandleFunc("/userID/{username}", getUserIDHandler).Methods("GET")
-	r.HandleFunc("/user/{userID}", getUserHandler).Methods("GET")
+	r.HandleFunc("/getUser", getUserHandler).Methods("GET")
 
 	fmt.Println("Server is running on port 5001")
 	r.Use(beforeRequest)

--- a/src/helpers.go
+++ b/src/helpers.go
@@ -26,7 +26,18 @@ func getLoggedInUser(r *http.Request) (*User) {
 
 
 func getUser(userID int) (*User, error) {
-	requestURL := fmt.Sprintf("%s/user/%d", serverEndpoint, userID)
+	requestURL := fmt.Sprintf("%s/getUser?userID=%d", serverEndpoint, userID)
+	res, err := http.Get(requestURL)
+	if err != nil {
+		fmt.Printf("error making http request to %s: %s\n", requestURL, err)
+		return nil, err
+	}
+	var user User
+	json.NewDecoder(res.Body).Decode(&user)
+	return &user, nil
+}
+func getUserFromUsername(username string) (*User, error) {
+	requestURL := fmt.Sprintf("%s/getUser?username=%s", serverEndpoint, username)
 	res, err := http.Get(requestURL)
 	if err != nil {
 		fmt.Printf("error making http request to %s: %s\n", requestURL, err)


### PR DESCRIPTION
This is relevant for logging to check whether users actually exists when our logs says it did not find them.